### PR TITLE
Add biometric authentication for database access

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,4 +39,5 @@ dependencies {
     kapt "androidx.room:room-compiler:2.6.1"
 
     implementation "androidx.security:security-crypto:1.1.0-alpha06"
+    implementation "androidx.biometric:biometric:1.1.0"
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     package="com.example.nfckeyring">
 
     <uses-permission android:name="android.permission.NFC" />
+    <uses-permission android:name="android.permission.USE_BIOMETRIC" />
     <uses-feature android:name="android.hardware.nfc" android:required="true" />
 
     <application

--- a/app/src/main/java/com/example/nfckeyring/MainActivity.kt
+++ b/app/src/main/java/com/example/nfckeyring/MainActivity.kt
@@ -5,6 +5,7 @@ import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import com.example.nfckeyring.ui.KeyViewModel
+import com.example.nfckeyring.util.BiometricAuth
 import com.example.nfckeyring.util.SecurePrefs
 import kotlinx.coroutines.launch
 
@@ -16,15 +17,19 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
-        lifecycleScope.launch {
-            viewModel.allKeys.collect { keys ->
-                // Observe keys; update UI as needed
+        BiometricAuth.authenticate(this, onSuccess = {
+            viewModel.initialize()
+            lifecycleScope.launch {
+                viewModel.allKeys.collect { keys ->
+                    // Observe keys; update UI as needed
+                }
             }
-        }
-
-        val prefs = SecurePrefs.getPrefs(this)
-        if (!prefs.contains("initialized")) {
-            prefs.edit().putBoolean("initialized", true).apply()
-        }
+            val prefs = SecurePrefs.getPrefs(this)
+            if (!prefs.contains("initialized")) {
+                prefs.edit().putBoolean("initialized", true).apply()
+            }
+        }, onError = {
+            finish()
+        })
     }
 }

--- a/app/src/main/java/com/example/nfckeyring/ui/KeyViewModel.kt
+++ b/app/src/main/java/com/example/nfckeyring/ui/KeyViewModel.kt
@@ -11,20 +11,25 @@ import kotlinx.coroutines.launch
 
 class KeyViewModel(application: Application) : AndroidViewModel(application) {
 
-    private val repository: KeyRepository
-    val allKeys: Flow<List<KeyEntity>>
+    private lateinit var repository: KeyRepository
+    lateinit var allKeys: Flow<List<KeyEntity>>
 
-    init {
-        val dao = AppDatabase.getDatabase(application).keyDao()
+    fun initialize() {
+        if (this::repository.isInitialized) return
+        val dao = AppDatabase.getDatabase(getApplication()).keyDao()
         repository = KeyRepository(dao)
         allKeys = repository.allKeys
     }
 
     fun insert(key: KeyEntity) = viewModelScope.launch {
-        repository.insert(key)
+        if (this::repository.isInitialized) {
+            repository.insert(key)
+        }
     }
 
     fun delete(key: KeyEntity) = viewModelScope.launch {
-        repository.delete(key)
+        if (this::repository.isInitialized) {
+            repository.delete(key)
+        }
     }
 }

--- a/app/src/main/java/com/example/nfckeyring/util/BiometricAuth.kt
+++ b/app/src/main/java/com/example/nfckeyring/util/BiometricAuth.kt
@@ -1,0 +1,35 @@
+package com.example.nfckeyring.util
+
+import androidx.biometric.BiometricManager
+import androidx.biometric.BiometricPrompt
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.FragmentActivity
+
+object BiometricAuth {
+    fun authenticate(
+        activity: FragmentActivity,
+        onSuccess: () -> Unit,
+        onError: (() -> Unit)? = null
+    ) {
+        val executor = ContextCompat.getMainExecutor(activity)
+        val prompt = BiometricPrompt(activity, executor, object : BiometricPrompt.AuthenticationCallback() {
+            override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
+                onSuccess()
+            }
+
+            override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
+                onError?.invoke()
+            }
+        })
+
+        val promptInfo = BiometricPrompt.PromptInfo.Builder()
+            .setTitle("Unlock")
+            .setSubtitle("Authenticate to access keys")
+            .setAllowedAuthenticators(
+                BiometricManager.Authenticators.BIOMETRIC_STRONG or BiometricManager.Authenticators.DEVICE_CREDENTIAL
+            )
+            .build()
+
+        prompt.authenticate(promptInfo)
+    }
+}


### PR DESCRIPTION
## Summary
- Require biometric or device credential before initializing database access
- Delay Room database initialization until after successful authentication
- Add biometric utility and permission

## Testing
- `gradle build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a74749c3e0832c8d0353682c7201df