### PR TITLE
Implement NFC foreground dispatch

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,7 +11,9 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.NfcKeyring">
-        <activity android:name=".MainActivity">
+        <activity
+            android:name=".MainActivity"
+            android:launchMode="singleTop">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/java/com/example/nfckeyring/MainActivity.kt
+++ b/app/src/main/java/com/example/nfckeyring/MainActivity.kt
@@ -1,6 +1,13 @@
 package com.example.nfckeyring
 
+import android.app.PendingIntent
+import android.content.Intent
+import android.content.IntentFilter
+import android.nfc.NfcAdapter
+import android.nfc.Tag
 import android.os.Bundle
+import android.util.Log
+import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
@@ -12,10 +19,26 @@ import kotlinx.coroutines.launch
 class MainActivity : AppCompatActivity() {
 
     private val viewModel: KeyViewModel by viewModels()
+    private var nfcAdapter: NfcAdapter? = null
+    private var nfcPendingIntent: PendingIntent? = null
+    private lateinit var nfcIntentFilters: Array<IntentFilter>
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
+        nfcAdapter = NfcAdapter.getDefaultAdapter(this)
+        val intent = Intent(this, javaClass).addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
+        nfcPendingIntent = PendingIntent.getActivity(
+            this,
+            0,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+        )
+        val tagDetected = IntentFilter(NfcAdapter.ACTION_TAG_DISCOVERED).apply {
+            addCategory(Intent.CATEGORY_DEFAULT)
+        }
+        nfcIntentFilters = arrayOf(tagDetected)
 
         BiometricAuth.authenticate(this, onSuccess = {
             viewModel.initialize()
@@ -31,5 +54,27 @@ class MainActivity : AppCompatActivity() {
         }, onError = {
             finish()
         })
+    }
+
+    override fun onResume() {
+        super.onResume()
+        nfcAdapter?.enableForegroundDispatch(this, nfcPendingIntent, nfcIntentFilters, null)
+    }
+
+    override fun onPause() {
+        super.onPause()
+        nfcAdapter?.disableForegroundDispatch(this)
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        if (NfcAdapter.ACTION_TAG_DISCOVERED == intent.action) {
+            val tag: Tag? = intent.getParcelableExtra(NfcAdapter.EXTRA_TAG)
+            tag?.let {
+                val tagId = it.id.joinToString("") { b -> "%02X".format(b) }
+                Toast.makeText(this, "Tag detected: $tagId", Toast.LENGTH_SHORT).show()
+                Log.d("MainActivity", "NFC Tag discovered: $tagId")
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Initialize NFC foreground dispatch in `MainActivity` with pending intent and tag handling.
- Manage dispatch lifecycle in `onResume`/`onPause` and show tag info on discovery.
- Configure `MainActivity` to use `singleTop` launch mode for NFC intents.

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7496603cc832c812bb091460bb131