### PR TITLE
Parse and display NFC tag contents

### DIFF
--- a/app/src/main/java/com/example/nfckeyring/MainActivity.kt
+++ b/app/src/main/java/com/example/nfckeyring/MainActivity.kt
@@ -3,10 +3,14 @@ package com.example.nfckeyring
 import android.app.PendingIntent
 import android.content.Intent
 import android.content.IntentFilter
+import android.nfc.Ndef
+import android.nfc.NdefMessage
+import android.nfc.NdefRecord
 import android.nfc.NfcAdapter
 import android.nfc.Tag
 import android.os.Bundle
 import android.util.Log
+import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -22,10 +26,17 @@ class MainActivity : AppCompatActivity() {
     private var nfcAdapter: NfcAdapter? = null
     private var nfcPendingIntent: PendingIntent? = null
     private lateinit var nfcIntentFilters: Array<IntentFilter>
+    private lateinit var tagUidTextView: TextView
+    private lateinit var formattedTextView: TextView
+    private lateinit var rawHexTextView: TextView
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
+        tagUidTextView = findViewById(R.id.tagUidTextView)
+        formattedTextView = findViewById(R.id.formattedTextView)
+        rawHexTextView = findViewById(R.id.rawHexTextView)
 
         nfcAdapter = NfcAdapter.getDefaultAdapter(this)
         val intent = Intent(this, javaClass).addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
@@ -71,10 +82,74 @@ class MainActivity : AppCompatActivity() {
         if (NfcAdapter.ACTION_TAG_DISCOVERED == intent.action) {
             val tag: Tag? = intent.getParcelableExtra(NfcAdapter.EXTRA_TAG)
             tag?.let {
-                val tagId = it.id.joinToString("") { b -> "%02X".format(b) }
+                val tagId = it.id.toHexString()
+                tagUidTextView.text = getString(R.string.tag_uid_label) + " " + tagId
                 Toast.makeText(this, "Tag detected: $tagId", Toast.LENGTH_SHORT).show()
                 Log.d("MainActivity", "NFC Tag discovered: $tagId")
+
+                val ndef = Ndef.get(it)
+                if (ndef != null) {
+                    val message = ndef.cachedNdefMessage
+                    if (message != null) {
+                        displayNdefMessage(message)
+                    } else {
+                        formattedTextView.text = getString(R.string.no_ndef)
+                        rawHexTextView.text = ""
+                    }
+                } else {
+                    formattedTextView.text = getString(R.string.no_ndef)
+                    rawHexTextView.text = ""
+                }
             }
         }
     }
+
+    private fun displayNdefMessage(message: NdefMessage) {
+        val formatted = StringBuilder()
+        val raw = StringBuilder()
+        for (record in message.records) {
+            raw.append(record.payload.toHexString()).append('\n')
+            formatted.append(
+                when {
+                    record.tnf == NdefRecord.TNF_WELL_KNOWN && record.type.contentEquals(NdefRecord.RTD_TEXT) ->
+                        "Text: ${parseTextRecord(record.payload)}"
+                    record.tnf == NdefRecord.TNF_WELL_KNOWN && record.type.contentEquals(NdefRecord.RTD_URI) ->
+                        "URI: ${record.toUri()}"
+                    record.tnf == NdefRecord.TNF_MIME_MEDIA && record.type.contentEquals("application/vnd.wfa.wsc".toByteArray()) ->
+                        "WiFi: ${parseWifiRecord(record.payload)}"
+                    else -> "Unknown record"
+                }
+            ).append('\n')
+        }
+        formattedTextView.text = formatted.toString().trim()
+        rawHexTextView.text = raw.toString().trim()
+    }
+
+    private fun parseTextRecord(payload: ByteArray): String {
+        val status = payload[0].toInt()
+        val isUtf16 = status and 0x80 != 0
+        val languageLength = status and 0x3F
+        val textEncoding = if (isUtf16) Charsets.UTF_16 else Charsets.UTF_8
+        return String(payload, 1 + languageLength, payload.size - 1 - languageLength, textEncoding)
+    }
+
+    private fun parseWifiRecord(payload: ByteArray): String {
+        var index = 0
+        val builder = StringBuilder()
+        while (index + 4 <= payload.size) {
+            val type = ((payload[index].toInt() and 0xFF) shl 8) or (payload[index + 1].toInt() and 0xFF)
+            val length = ((payload[index + 2].toInt() and 0xFF) shl 8) or (payload[index + 3].toInt() and 0xFF)
+            if (index + 4 + length > payload.size) break
+            val value = payload.copyOfRange(index + 4, index + 4 + length)
+            when (type) {
+                0x1045 -> builder.append("SSID: ").append(String(value)).append(' ')
+                0x1027 -> builder.append("Password: ").append(String(value)).append(' ')
+            }
+            index += 4 + length
+        }
+        val result = builder.toString().trim()
+        return if (result.isNotEmpty()) result else "WiFi config data"
+    }
+
+    private fun ByteArray.toHexString(): String = joinToString(" ") { "%02X".format(it) }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -2,11 +2,27 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:gravity="center"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:padding="16dp">
 
     <TextView
-        android:layout_width="wrap_content"
+        android:id="@+id/tagUidTextView"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Hello NFC Keyring!" />
+        android:text="@string/tag_uid_label" />
+
+    <TextView
+        android:id="@+id/formattedTextView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/formatted_label" />
+
+    <TextView
+        android:id="@+id/rawHexTextView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/raw_hex_label" />
+
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,7 @@
 <resources>
     <string name="app_name">NFC Keyring</string>
+    <string name="tag_uid_label">Tag UID:</string>
+    <string name="formatted_label">Formatted Data:</string>
+    <string name="raw_hex_label">Raw Hex:</string>
+    <string name="no_ndef">No NDEF data</string>
 </resources>


### PR DESCRIPTION
## Summary
- read NFC tag UID and extract NDEF payloads
- show formatted text/URI/WiFi data and raw hex in the UI

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a74b53acb4832cb7865b31635cfeb2