### PR TITLE
Add tag detail screen with emulation button

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name=".ui.TagDetailActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/nfckeyring/MainActivity.kt
+++ b/app/src/main/java/com/example/nfckeyring/MainActivity.kt
@@ -21,6 +21,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.example.nfckeyring.data.TagEntity
 import com.example.nfckeyring.ui.TagViewModel
 import com.example.nfckeyring.ui.TagListAdapter
+import com.example.nfckeyring.ui.TagDetailActivity
 import com.example.nfckeyring.util.BiometricAuth
 import com.example.nfckeyring.util.SecurePrefs
 import kotlinx.coroutines.launch
@@ -46,6 +47,7 @@ class MainActivity : AppCompatActivity() {
 
         val recyclerView = findViewById<RecyclerView>(R.id.tagRecyclerView)
         tagAdapter = TagListAdapter(
+            onClick = { openDetail(it) },
             onRename = { showRenameDialog(it) },
             onEdit = { showEditDialog(it) },
             onDelete = { showDeleteDialog(it) }
@@ -170,6 +172,13 @@ class MainActivity : AppCompatActivity() {
             }
             .setNegativeButton(R.string.cancel, null)
             .show()
+    }
+
+    private fun openDetail(tag: TagEntity) {
+        val intent = Intent(this, TagDetailActivity::class.java).apply {
+            putExtra("tag", tag)
+        }
+        startActivity(intent)
     }
 
     private fun displayNdefMessage(message: NdefMessage): Pair<String, String> {

--- a/app/src/main/java/com/example/nfckeyring/data/TagEntity.kt
+++ b/app/src/main/java/com/example/nfckeyring/data/TagEntity.kt
@@ -2,6 +2,7 @@ package com.example.nfckeyring.data
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import java.io.Serializable
 
 @Entity(tableName = "tags")
 data class TagEntity(
@@ -11,4 +12,4 @@ data class TagEntity(
     val payload: String,
     val label: String,
     val createdAt: Long
-)
+) : Serializable

--- a/app/src/main/java/com/example/nfckeyring/ui/TagDetailActivity.kt
+++ b/app/src/main/java/com/example/nfckeyring/ui/TagDetailActivity.kt
@@ -1,0 +1,51 @@
+package com.example.nfckeyring.ui
+
+import android.os.Bundle
+import android.widget.Button
+import android.widget.TextView
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import com.example.nfckeyring.R
+import com.example.nfckeyring.data.TagEntity
+
+class TagDetailActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_tag_detail)
+
+        val tag = intent.getSerializableExtra("tag") as? TagEntity
+        val labelView = findViewById<TextView>(R.id.tagLabelTextView)
+        val formattedView = findViewById<TextView>(R.id.formattedTextView)
+        val rawView = findViewById<TextView>(R.id.rawHexTextView)
+        val emulateButton = findViewById<Button>(R.id.emulateButton)
+
+        tag?.let {
+            labelView.text = it.label
+            formattedView.text = formatPayload(it.payload)
+            rawView.text = it.payload
+            emulateButton.setOnClickListener { _ ->
+                Toast.makeText(this, getString(R.string.emulation_started, it.label), Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    private fun formatPayload(payload: String): String {
+        return try {
+            val bytes = payload.split(" ")
+                .filter { it.isNotBlank() }
+                .map { it.toInt(16).toByte() }
+                .toByteArray()
+            if (bytes.isNotEmpty()) {
+                val status = bytes[0].toInt()
+                val isUtf16 = status and 0x80 != 0
+                val languageLength = status and 0x3F
+                val textEncoding = if (isUtf16) Charsets.UTF_16 else Charsets.UTF_8
+                String(bytes, 1 + languageLength, bytes.size - 1 - languageLength, textEncoding)
+            } else {
+                ""
+            }
+        } catch (e: Exception) {
+            ""
+        }
+    }
+}

--- a/app/src/main/java/com/example/nfckeyring/ui/TagListAdapter.kt
+++ b/app/src/main/java/com/example/nfckeyring/ui/TagListAdapter.kt
@@ -10,6 +10,7 @@ import com.example.nfckeyring.R
 import com.example.nfckeyring.data.TagEntity
 
 class TagListAdapter(
+    private val onClick: (TagEntity) -> Unit,
     private val onRename: (TagEntity) -> Unit,
     private val onEdit: (TagEntity) -> Unit,
     private val onDelete: (TagEntity) -> Unit
@@ -34,6 +35,7 @@ class TagListAdapter(
         holder.renameButton.setOnClickListener { onRename(tag) }
         holder.editButton.setOnClickListener { onEdit(tag) }
         holder.deleteButton.setOnClickListener { onDelete(tag) }
+        holder.itemView.setOnClickListener { onClick(tag) }
     }
 
     override fun getItemCount(): Int = tags.size

--- a/app/src/main/res/layout/activity_tag_detail.xml
+++ b/app/src/main/res/layout/activity_tag_detail.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/tagLabelTextView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Tag" />
+
+    <TextView
+        android:id="@+id/formattedTextView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/formatted_label" />
+
+    <TextView
+        android:id="@+id/rawHexTextView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/raw_hex_label" />
+
+    <Button
+        android:id="@+id/emulateButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:text="@string/activate_emulation" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,4 +13,6 @@
     <string name="confirm_delete">Are you sure you want to delete this tag?</string>
     <string name="save">Save</string>
     <string name="cancel">Cancel</string>
+    <string name="activate_emulation">Activate Emulation</string>
+    <string name="emulation_started">Emulation activated for %1$s</string>
 </resources>


### PR DESCRIPTION
## Summary
- add dedicated TagDetailActivity to show formatted and raw payload
- enable navigation from list items to detail view
- include 'Activate Emulation' button placeholder

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a754d26dfc832c9ee74efc2d37e72a