### PR TITLE
Add basic Host Card Emulation service

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,6 +20,17 @@
             </intent-filter>
         </activity>
         <activity android:name=".ui.TagDetailActivity" />
+        <service
+            android:name=".hce.TestHostApduService"
+            android:exported="true"
+            android:permission="android.permission.BIND_NFC_SERVICE">
+            <intent-filter>
+                <action android:name="android.nfc.cardemulation.action.HOST_APDU_SERVICE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.nfc.cardemulation.host_apdu_service"
+                android:resource="@xml/apduservice" />
+        </service>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/nfckeyring/hce/TestHostApduService.kt
+++ b/app/src/main/java/com/example/nfckeyring/hce/TestHostApduService.kt
@@ -1,0 +1,38 @@
+package com.example.nfckeyring.hce
+
+import android.nfc.cardemulation.HostApduService
+import android.os.Bundle
+
+class TestHostApduService : HostApduService() {
+    override fun processCommandApdu(commandApdu: ByteArray?, extras: Bundle?): ByteArray {
+        val selectApdu = buildSelectApdu(TEST_AID)
+        return if (commandApdu != null && commandApdu.contentEquals(selectApdu)) {
+            STATIC_RESPONSE + STATUS_SUCCESS
+        } else {
+            UNKNOWN_CMD_SW
+        }
+    }
+
+    override fun onDeactivated(reason: Int) {
+        // No-op for demo
+    }
+
+    companion object {
+        private const val TEST_AID = "F00102030405"
+        private val STATUS_SUCCESS = byteArrayOf(0x90.toByte(), 0x00)
+        private val UNKNOWN_CMD_SW = byteArrayOf(0x6A.toByte(), 0x82.toByte())
+        private val STATIC_RESPONSE = "01020304".hexToBytes()
+        private val SELECT_APDU_HEADER = byteArrayOf(0x00.toByte(), 0xA4.toByte(), 0x04, 0x00)
+
+        private fun buildSelectApdu(aid: String): ByteArray {
+            val aidBytes = aid.hexToBytes()
+            val length = aidBytes.size.toByte()
+            return SELECT_APDU_HEADER + byteArrayOf(length) + aidBytes
+        }
+
+        private fun String.hexToBytes(): ByteArray {
+            check(length % 2 == 0) { "Hex string must have even length" }
+            return chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+        }
+    }
+}

--- a/app/src/main/res/xml/apduservice.xml
+++ b/app/src/main/res/xml/apduservice.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<host-apdu-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:description="@string/app_name"
+    android:requireDeviceUnlock="false">
+    <aid-group android:description="@string/app_name" android:category="other">
+        <aid-filter android:name="F00102030405" />
+    </aid-group>
+</host-apdu-service>


### PR DESCRIPTION
## Summary
- implement `TestHostApduService` to respond to a test AID with a static APDU payload
- declare AID filter and register the service in the manifest

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a757aa248c832c86b8c18014c33bc4