### PR TITLE
Add UI controls for NFC tag emulation

### DIFF
--- a/app/src/main/java/com/example/nfckeyring/ui/TagDetailActivity.kt
+++ b/app/src/main/java/com/example/nfckeyring/ui/TagDetailActivity.kt
@@ -1,6 +1,7 @@
 package com.example.nfckeyring.ui
 
 import android.os.Bundle
+import android.view.View
 import android.widget.Button
 import android.widget.TextView
 import android.widget.Toast
@@ -19,19 +20,43 @@ class TagDetailActivity : AppCompatActivity() {
         val formattedView = findViewById<TextView>(R.id.formattedTextView)
         val rawView = findViewById<TextView>(R.id.rawHexTextView)
         val emulateButton = findViewById<Button>(R.id.emulateButton)
+        val statusView = findViewById<TextView>(R.id.emulationStatusTextView)
+        val stopButton = findViewById<Button>(R.id.stopButton)
 
-        tag?.let {
-            labelView.text = it.label
-            formattedView.text = formatPayload(it.payload)
-            rawView.text = it.payload
-            emulateButton.setOnClickListener { _ ->
-                val prefs = SecurePrefs.getPrefs(this)
-                prefs.edit().putInt("selected_tag_id", it.id).apply()
+        tag?.let { currentTag ->
+            labelView.text = currentTag.label
+            formattedView.text = formatPayload(currentTag.payload)
+            rawView.text = currentTag.payload
+            val prefs = SecurePrefs.getPrefs(this)
+            val selectedId = prefs.getInt("selected_tag_id", -1)
+            if (selectedId == currentTag.id) {
+                statusView.visibility = View.VISIBLE
+                stopButton.visibility = View.VISIBLE
+                emulateButton.visibility = View.GONE
+            }
+
+            emulateButton.setOnClickListener {
+                prefs.edit().putInt("selected_tag_id", currentTag.id).apply()
                 Toast.makeText(
                     this,
-                    getString(R.string.emulation_started, it.label),
+                    getString(R.string.emulation_started, currentTag.label),
                     Toast.LENGTH_SHORT
                 ).show()
+                statusView.visibility = View.VISIBLE
+                stopButton.visibility = View.VISIBLE
+                emulateButton.visibility = View.GONE
+            }
+
+            stopButton.setOnClickListener {
+                prefs.edit().remove("selected_tag_id").apply()
+                Toast.makeText(
+                    this,
+                    getString(R.string.emulation_stopped),
+                    Toast.LENGTH_SHORT
+                ).show()
+                statusView.visibility = View.GONE
+                stopButton.visibility = View.GONE
+                emulateButton.visibility = View.VISIBLE
             }
         }
     }

--- a/app/src/main/res/layout/activity_tag_detail.xml
+++ b/app/src/main/res/layout/activity_tag_detail.xml
@@ -32,4 +32,20 @@
         android:layout_marginTop="24dp"
         android:text="@string/activate_emulation" />
 
+    <TextView
+        android:id="@+id/emulationStatusTextView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/emulation_active"
+        android:visibility="gone" />
+
+    <Button
+        android:id="@+id/stopButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="@string/stop_emulation"
+        android:visibility="gone" />
+
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,4 +15,7 @@
     <string name="cancel">Cancel</string>
     <string name="activate_emulation">Activate Emulation</string>
     <string name="emulation_started">Emulation activated for %1$s</string>
+    <string name="emulation_active">Active Tag Emulation</string>
+    <string name="stop_emulation">Stop Emulation</string>
+    <string name="emulation_stopped">Emulation stopped</string>
 </resources>


### PR DESCRIPTION
## Summary
- show indicator when a tag is being emulated
- allow stopping tag emulation from the detail screen

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a759cf5dc0832cab122bd160d17525